### PR TITLE
fix: remove unexpected double dash in table

### DIFF
--- a/src/themes/rhdh/componentOverrides.ts
+++ b/src/themes/rhdh/componentOverrides.ts
@@ -331,6 +331,10 @@ export const components = (
           '& > th[class*="MuiTableCell-head"]': {
             backgroundColor: themePalette.general.tableBackgroundColor,
           },
+          // only child of td is an empty table row for separators, not an actual empty table cell
+          '& > td:not(:only-child):empty::before': {
+            content: '"--"',
+          }
         },
       },
     },
@@ -357,10 +361,8 @@ export const components = (
         body: {
           fontWeight: "normal !important",
           color: themePalette.general.tableTitleColor,
-          "&:empty::before": {
-            content: '"--"',
-          },
-          "& > div > span:empty::before": {
+          // any other empty spans rather than the first one are for icons, not actual empty table cells
+          "& > div > span:first-child:empty::before": {
             content: '"--"',
           },
           '& > div[class*="MuiChip-sizeSmall"]': {

--- a/src/themes/rhdh/componentOverrides.ts
+++ b/src/themes/rhdh/componentOverrides.ts
@@ -332,9 +332,9 @@ export const components = (
             backgroundColor: themePalette.general.tableBackgroundColor,
           },
           // only child of td is an empty table row for separators, not an actual empty table cell
-          '& > td:not(:only-child):empty::before': {
+          "& > td:not(:only-child):empty::before": {
             content: '"--"',
-          }
+          },
         },
       },
     },


### PR DESCRIPTION
This is for [RHIDP-2300](https://issues.redhat.com/browse/RHIDP-2300)

**Steps to test**:
1. Pull the code to your local and remove `./dist/*` if exist already
2. Run `yarn build` to generate `./dist/` files
3. Go to your `backstage-showcase/packages/app/package.json` and update dependency to have
```
"@redhat-developer/red-hat-developer-hub-theme": "link:path/to/your/local/red-hat-developer-hub-theme/directory",
// i.e.
"@redhat-developer/red-hat-developer-hub-theme": "link:../../../red-hat-developer-hub-theme",
```

**Screen recording for the fix**

https://github.com/redhat-developer/red-hat-developer-hub-theme/assets/26255262/22b8d218-04f7-48d8-ba8f-bc560d9c7d92
