### PR TITLE
fix: removed double dashes for empty table cells

### DIFF
--- a/src/themes/rhdh/componentOverrides.ts
+++ b/src/themes/rhdh/componentOverrides.ts
@@ -328,10 +328,6 @@ export const components = (
           '& > th[class*="MuiTableCell-head"]': {
             backgroundColor: themePalette.general.tableBackgroundColor,
           },
-          // only child of td is an empty table row for separators, not an actual empty table cell
-          "& > td:not(:only-child):empty::before": {
-            content: '"--"',
-          },
         },
       },
     },
@@ -358,10 +354,6 @@ export const components = (
         body: {
           fontWeight: "normal !important",
           color: themePalette.general.tableTitleColor,
-          // any other empty spans rather than the first one are for icons, not actual empty table cells
-          "& > div > span:first-child:empty::before": {
-            content: '"--"',
-          },
           '& > div[class*="MuiChip-sizeSmall"]': {
             margin: "2px",
           },


### PR DESCRIPTION
Remove "--" filler for empty table cells as MUI table adds empty rows on itself, and it's hard for us to track everywhere it adds empty rows.