### PR TITLE
Use primary color as tab indicator

### DIFF
--- a/.github/workflows/release-npm-package.yaml
+++ b/.github/workflows/release-npm-package.yaml
@@ -23,7 +23,7 @@ jobs:
         run: |
           latest_version=$(npm view @redhat-developer/red-hat-developer-hub-theme@latest version)
           npm version $latest_version --no-git-tag-version
-          npm version minor           --no-git-tag-version
+          npm version patch           --no-git-tag-version
           npm publish --access=public --tag=latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/src/themes/rhdh/components.ts
+++ b/src/themes/rhdh/components.ts
@@ -451,13 +451,6 @@ export const components = (themeConfig: ThemeConfig): Components => {
   // MUI tabs
   if (options.tabs !== "mui") {
     components.MuiTabs = {
-      defaultProps: {
-        TabIndicatorProps: {
-          style: {
-            background: rhdhPrimary.main,
-          },
-        },
-      },
       styleOverrides: {
         root: {
           boxShadow: `0 -1px ${general.tabsBottomBorderColor} inset`,


### PR DESCRIPTION
With app-config:

```yaml
app:
  title: Scaffolded Backstage App
  baseUrl: http://localhost:3000
  branding:
    theme:
      dark:
        primaryColor: '#ff0000'
        headerColor1: '#00ff00'
        headerColor2: '#0000ff'
        navigationIndicatorColor: '#ffff00'
        palette:
          primary:
            main: '#00ffff'
```

Before it uses the navigation indicator for all tab indicators:

![image](https://github.com/user-attachments/assets/48b98ce4-b010-48ed-bbf9-a9c7375a4ddd)


With this change:

![image](https://github.com/user-attachments/assets/1cd1cce4-ab98-4c7c-ae10-96c9e8429d1e)

