### PR TITLE
Remove some header rules to allow font color customization

### DIFF
--- a/src/hooks/useThemeOptions.test.ts
+++ b/src/hooks/useThemeOptions.test.ts
@@ -14,7 +14,7 @@ describe("useThemeOptions", () => {
         default: {
           backgroundImage: "none,  linear-gradient(90deg, #ffffff, #ffffff)",
           colors: ["#ffffff"],
-          fontColor: "#FFFFFF",
+          fontColor: "#000000",
           shape: "none",
         },
       },
@@ -39,7 +39,7 @@ describe("useThemeOptions", () => {
         default: {
           backgroundImage: "none,  linear-gradient(90deg, #0f1214, #0f1214)",
           colors: ["#0f1214"],
-          fontColor: "#FFFFFF",
+          fontColor: "#ffffff",
           shape: "none",
         },
       },

--- a/src/themes/rhdh/components.ts
+++ b/src/themes/rhdh/components.ts
@@ -29,11 +29,11 @@ export const components = (themeConfig: ThemeConfig): Components => {
 
   const palette = themeConfig.palette ?? {};
 
-  const rhdh = palette.rhdh;
-  const general = rhdh?.general || ({} as RHDHThemePalette["general"]);
-  const rhdhPrimary = rhdh?.primary || ({} as RHDHThemePalette["primary"]);
+  const general = palette.rhdh?.general || ({} as RHDHThemePalette["general"]);
+  const rhdhPrimary =
+    palette.rhdh?.primary || ({} as RHDHThemePalette["primary"]);
   const rhdhSecondary =
-    rhdh?.secondary || ({} as RHDHThemePalette["secondary"]);
+    palette.rhdh?.secondary || ({} as RHDHThemePalette["secondary"]);
 
   const components: Components = {};
   if (options.components === "backstage" || options.components === "mui") {
@@ -276,7 +276,6 @@ export const components = (themeConfig: ThemeConfig): Components => {
           backgroundColor: general.cardBackgroundColor,
           '& > div > div > h2[class*="MuiTypography-h2-"]': {
             textTransform: "unset",
-            color: general.cardSubtitleColor,
             opacity: "40%",
           },
           '& > div > div > div[class*="MuiChip-sizeSmall"]': {
@@ -509,45 +508,14 @@ export const components = (themeConfig: ThemeConfig): Components => {
     components.BackstageHeader = {
       styleOverrides: {
         header: {
-          // color: general.headerTextColor,
-          // backgroundImage: `none, linear-gradient(90deg, ${headerColor1}, ${headerColor2})`,
-          // backgroundColor: general.headerBackgroundColor,
           boxShadow: "none",
           borderBottom: `1px solid ${general.headerBottomBorderColor}`,
         },
         title: {
-          color: general.cardSubtitleColor,
           fontWeight: "bold",
           '&[class*="MuiTypography-h1-"]': {
             fontWeight: "bold",
             fontSize: "2rem",
-          },
-        },
-        leftItemsBox: {
-          color: general.headerTextColor,
-          "& > nav": {
-            color: general.headerTextColor,
-          },
-          "& > p": {
-            color: general.headerTextColor,
-          },
-          "& > span": {
-            color: general.headerTextColor,
-          },
-        },
-        rightItemsBox: {
-          color: general.headerTextColor,
-          "& div": {
-            color: general.headerTextColor,
-          },
-          "& p": {
-            color: general.headerTextColor,
-          },
-          "& a": {
-            color: general.headerTextColor,
-          },
-          "& button": {
-            color: general.headerTextColor,
           },
         },
       },
@@ -556,20 +524,13 @@ export const components = (themeConfig: ThemeConfig): Components => {
       styleOverrides: {
         root: {
           '&[class*="MuiBox-root-"]': {
-            color: general.headerTextColor,
-            backgroundImage: "none",
-            backgroundColor: general.headerBackgroundColor,
+            color: palette.rhdh?.cards?.headerTextColor,
+            backgroundColor: palette.rhdh?.cards?.headerBackgroundColor,
+            backgroundImage: palette.rhdh?.cards?.headerBackgroundImage,
             borderBottom: `1px solid ${general.cardBorderColor}`,
           },
           '& > h3[class*="MuiTypography-subtitle2-"] > div > div:first-child': {
-            color: general.tableSubtitleColor,
             textTransform: "capitalize",
-          },
-          '& > h3[class*="MuiTypography-subtitle2-"] > div > div:last-child': {
-            color: general.cardSubtitleColor,
-          },
-          '& > h4[class*="MuiTypography-h6-"]': {
-            color: general.cardSubtitleColor,
           },
         },
       },

--- a/src/themes/rhdh/darkTheme.test.ts
+++ b/src/themes/rhdh/darkTheme.test.ts
@@ -82,12 +82,9 @@ describe("customDarkTheme", () => {
           searchBarBorderColor: "#57585a",
           formControlBackgroundColor: "#36373A",
           mainSectionBackgroundColor: "#0f1214",
-          headerBackgroundColor: "#0f1214",
-          headerTextColor: "#FFF",
           headerBottomBorderColor: "#A3A3A3",
           cardBackgroundColor: "#292929",
           sideBarBackgroundColor: "#1b1d21",
-          cardSubtitleColor: "#FFF",
           cardBorderColor: "#A3A3A3",
           tableTitleColor: "#E0E0E0",
           tableSubtitleColor: "#E0E0E0",
@@ -105,6 +102,11 @@ describe("customDarkTheme", () => {
         secondary: {
           main: "#B2A3FF",
           focusVisibleBorder: "#D0C7FF",
+        },
+        cards: {
+          headerTextColor: "#FFF",
+          headerBackgroundColor: "#0f1214",
+          headerBackgroundImage: "none",
         },
       },
     });

--- a/src/themes/rhdh/darkTheme.ts
+++ b/src/themes/rhdh/darkTheme.ts
@@ -31,12 +31,9 @@ export const customDarkTheme = (): ThemeConfigPalette => {
         searchBarBorderColor: "#57585a",
         formControlBackgroundColor: "#36373A",
         mainSectionBackgroundColor: "#0f1214",
-        headerBackgroundColor: "#0f1214",
-        headerTextColor: "#FFF",
         headerBottomBorderColor: "#A3A3A3",
         cardBackgroundColor: "#292929",
         sideBarBackgroundColor: "#1b1d21",
-        cardSubtitleColor: "#FFF",
         cardBorderColor: "#A3A3A3",
         tableTitleColor: "#E0E0E0",
         tableSubtitleColor: "#E0E0E0",
@@ -54,6 +51,11 @@ export const customDarkTheme = (): ThemeConfigPalette => {
       secondary: {
         main: "#B2A3FF",
         focusVisibleBorder: "#D0C7FF",
+      },
+      cards: {
+        headerTextColor: "#FFF",
+        headerBackgroundColor: "#0f1214",
+        headerBackgroundImage: "none",
       },
     },
   };

--- a/src/themes/rhdh/index.ts
+++ b/src/themes/rhdh/index.ts
@@ -19,6 +19,7 @@ export const getDefaultThemeConfig = (mode: "light" | "dark"): ThemeConfig => {
     pageTheme: {
       default: {
         backgroundColor: mode === "dark" ? "#0f1214" : "#ffffff",
+        fontColor: mode === "dark" ? "#ffffff" : "#000000",
       },
     },
     options: {},

--- a/src/themes/rhdh/lightTheme.test.ts
+++ b/src/themes/rhdh/lightTheme.test.ts
@@ -86,12 +86,9 @@ describe("customLightTheme", () => {
           searchBarBorderColor: "#E4E4E4",
           formControlBackgroundColor: "#FFF",
           mainSectionBackgroundColor: "#FFF",
-          headerBackgroundColor: "#FFF",
-          headerTextColor: "#151515",
           headerBottomBorderColor: "#C7C7C7",
           cardBackgroundColor: "#FFF",
           sideBarBackgroundColor: "#212427",
-          cardSubtitleColor: "#000",
           cardBorderColor: "#C7C7C7",
           tableTitleColor: "#181818",
           tableSubtitleColor: "#616161",
@@ -109,6 +106,11 @@ describe("customLightTheme", () => {
         secondary: {
           main: "#8476D1",
           focusVisibleBorder: "#8476D1",
+        },
+        cards: {
+          headerTextColor: "#151515",
+          headerBackgroundColor: "#FFF",
+          headerBackgroundImage: "none",
         },
       },
     });

--- a/src/themes/rhdh/lightTheme.ts
+++ b/src/themes/rhdh/lightTheme.ts
@@ -35,12 +35,9 @@ export const customLightTheme = (): ThemeConfigPalette => {
         searchBarBorderColor: "#E4E4E4",
         formControlBackgroundColor: "#FFF",
         mainSectionBackgroundColor: "#FFF",
-        headerBackgroundColor: "#FFF",
-        headerTextColor: "#151515",
         headerBottomBorderColor: "#C7C7C7",
         cardBackgroundColor: "#FFF",
         sideBarBackgroundColor: "#212427",
-        cardSubtitleColor: "#000",
         cardBorderColor: "#C7C7C7",
         tableTitleColor: "#181818",
         tableSubtitleColor: "#616161",
@@ -58,6 +55,11 @@ export const customLightTheme = (): ThemeConfigPalette => {
       secondary: {
         main: "#8476D1",
         focusVisibleBorder: "#8476D1",
+      },
+      cards: {
+        headerTextColor: "#151515",
+        headerBackgroundColor: "#FFF",
+        headerBackgroundImage: "none",
       },
     },
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,12 +9,9 @@ export interface RHDHThemePalette {
     searchBarBorderColor: string;
     formControlBackgroundColor: string;
     mainSectionBackgroundColor: string;
-    headerBackgroundColor: string;
-    headerTextColor: string;
     headerBottomBorderColor: string;
     cardBackgroundColor: string;
     sideBarBackgroundColor: string;
-    cardSubtitleColor: string;
     cardBorderColor: string;
     tableTitleColor: string;
     tableSubtitleColor: string;
@@ -34,6 +31,12 @@ export interface RHDHThemePalette {
   secondary: {
     main: string;
     focusVisibleBorder: string;
+  };
+
+  cards?: {
+    headerTextColor: string;
+    headerBackgroundColor: string;
+    headerBackgroundImage: string;
   };
 }
 

--- a/src/utils/migrateTheme.test.ts
+++ b/src/utils/migrateTheme.test.ts
@@ -126,6 +126,34 @@ const testCases: TestCase[] = [
     },
   },
   {
+    name: "Pass pageThemes",
+    config: {
+      pageTheme: {
+        default: {
+          fontColor: "#000000",
+          backgroundColor: "#ff0000",
+        },
+        gradient: {
+          fontColor: "#000000",
+          backgroundColor: ["#00ff00", "#0000ff"],
+        },
+      },
+    },
+    expected: {
+      palette: {},
+      pageTheme: {
+        default: {
+          fontColor: "#000000",
+          backgroundColor: "#ff0000",
+        },
+        gradient: {
+          fontColor: "#000000",
+          backgroundColor: ["#00ff00", "#0000ff"],
+        },
+      },
+    },
+  },
+  {
     name: "Pass options as well",
     config: {
       options: {


### PR DESCRIPTION
## Default without customization didn't changed

### Light

![Screenshot from 2024-07-19 00-21-13](https://github.com/user-attachments/assets/aaa4ece7-54b8-404a-bec7-32fce26fc8e2)

![Screenshot from 2024-07-19 00-53-12](https://github.com/user-attachments/assets/b93086e1-6d76-45dc-a506-0f6da4161284)

### Dark

![Screenshot from 2024-07-19 00-21-36](https://github.com/user-attachments/assets/b711ce4c-92ec-4fe1-bd66-6b8bf043ac3e)

![Screenshot from 2024-07-19 00-53-29](https://github.com/user-attachments/assets/f85cfc7d-4126-4f9a-9e9c-3f39ac687452)

## With customization in `app-config.yaml`

```yaml
app:
  branding:
    theme:
      dark:
        pageTheme:
          default:
            backgroundColor: ['#ffff00', '#ff00ff']
            fontColor: '#808080'
```

### Without this PR Light

![Screenshot from 2024-07-19 00-28-15](https://github.com/user-attachments/assets/e349a67f-fed1-43f5-88ab-55eed50ae0b8)

![Screenshot from 2024-07-19 00-28-37](https://github.com/user-attachments/assets/5821ec8b-9cb2-473c-ba1a-d24d204ad47b)

### Without this PR Dark

![Screenshot from 2024-07-19 00-28-53](https://github.com/user-attachments/assets/bcd86309-6a46-490f-bb05-b73716c45c42)

![Screenshot from 2024-07-19 00-29-00](https://github.com/user-attachments/assets/0515784e-7fdd-4967-ac8a-bc1162d382fe)

### With this PR Light

![Screenshot from 2024-07-19 00-24-02](https://github.com/user-attachments/assets/82f8bb5e-a4cc-4e13-944f-490e9596cb00)

![Screenshot from 2024-07-19 00-52-52](https://github.com/user-attachments/assets/71943c08-da24-44aa-b85a-f2b290d116e3)

### With this PR Dark

![Screenshot from 2024-07-19 00-23-40](https://github.com/user-attachments/assets/52704469-e0d2-47bf-8544-1ee9e1e554d0)

![Screenshot from 2024-07-19 00-52-40](https://github.com/user-attachments/assets/5a75495c-ce72-41b1-a6e2-f6902dc1fd7c)
