### PR TITLE
RHIDP-3799: Updated card color in dark theme

### DIFF
--- a/src/themes/rhdh-1.2.0/defaultThemePalette.ts
+++ b/src/themes/rhdh-1.2.0/defaultThemePalette.ts
@@ -12,7 +12,7 @@ export const defaultThemePalette = (mode: string, themeColors: ThemeColors) => {
         headerBackgroundColor: "#0f1214",
         headerTextColor: "#FFF",
         headerBottomBorderColor: "#A3A3A3",
-        cardBackgroundColor: "#1b1d21",
+        cardBackgroundColor: "#292929",
         focusVisibleBorder: "#ADD6FF",
         sideBarBackgroundColor: "#1b1d21",
         cardSubtitleColor: "#FFF",

--- a/src/themes/rhdh-1.2.0/defaultThemePalette.ts
+++ b/src/themes/rhdh-1.2.0/defaultThemePalette.ts
@@ -12,7 +12,7 @@ export const defaultThemePalette = (mode: string, themeColors: ThemeColors) => {
         headerBackgroundColor: "#0f1214",
         headerTextColor: "#FFF",
         headerBottomBorderColor: "#A3A3A3",
-        cardBackgroundColor: "#292929",
+        cardBackgroundColor: "#1b1d21",
         focusVisibleBorder: "#ADD6FF",
         sideBarBackgroundColor: "#1b1d21",
         cardSubtitleColor: "#FFF",

--- a/src/themes/rhdh/darkTheme.test.ts
+++ b/src/themes/rhdh/darkTheme.test.ts
@@ -83,7 +83,7 @@ describe("customDarkTheme", () => {
           formControlBackgroundColor: "#36373A",
           mainSectionBackgroundColor: "#0f1214",
           headerBottomBorderColor: "#A3A3A3",
-          cardBackgroundColor: "#292929",
+          cardBackgroundColor: "#1b1d21",
           sideBarBackgroundColor: "#1b1d21",
           cardBorderColor: "#A3A3A3",
           tableTitleColor: "#E0E0E0",

--- a/src/themes/rhdh/darkTheme.ts
+++ b/src/themes/rhdh/darkTheme.ts
@@ -32,7 +32,7 @@ export const customDarkTheme = (): ThemeConfigPalette => {
         formControlBackgroundColor: "#36373A",
         mainSectionBackgroundColor: "#0f1214",
         headerBottomBorderColor: "#A3A3A3",
-        cardBackgroundColor: "#292929",
+        cardBackgroundColor: "#1b1d21",
         sideBarBackgroundColor: "#1b1d21",
         cardBorderColor: "#A3A3A3",
         tableTitleColor: "#E0E0E0",


### PR DESCRIPTION
This is for [RHIDP-3799](https://issues.redhat.com/browse/RHIDP-3799). Updated card background color to match PF5 in dark theme.

Screen recording:


https://github.com/user-attachments/assets/b02df5ca-522a-4a56-a27d-aeaabe8d944f

