### PR TITLE
Remove code that overrides the search bar background color

### DIFF
--- a/src/themes/rhdh/components.ts
+++ b/src/themes/rhdh/components.ts
@@ -481,13 +481,6 @@ export const components = (themeConfig: ThemeConfig): Components => {
       styleOverrides: {
         root: {
           backgroundColor: general.mainSectionBackgroundColor,
-          "& div:first-child": {
-            '& > div[class*="-searchBar"]': {
-              backgroundColor: general.formControlBackgroundColor,
-              border: `1px solid ${general.searchBarBorderColor}`,
-              boxShadow: "none",
-            },
-          },
         },
       },
     };

--- a/src/themes/rhdh/darkTheme.test.ts
+++ b/src/themes/rhdh/darkTheme.test.ts
@@ -79,7 +79,6 @@ describe("customDarkTheme", () => {
         general: {
           disabledBackground: "#444548",
           disabled: "#AAABAC",
-          searchBarBorderColor: "#57585a",
           formControlBackgroundColor: "#36373A",
           mainSectionBackgroundColor: "#0f1214",
           headerBottomBorderColor: "#A3A3A3",

--- a/src/themes/rhdh/darkTheme.ts
+++ b/src/themes/rhdh/darkTheme.ts
@@ -28,7 +28,6 @@ export const customDarkTheme = (): ThemeConfigPalette => {
       general: {
         disabledBackground: "#444548",
         disabled: "#AAABAC",
-        searchBarBorderColor: "#57585a",
         formControlBackgroundColor: "#36373A",
         mainSectionBackgroundColor: "#0f1214",
         headerBottomBorderColor: "#A3A3A3",

--- a/src/themes/rhdh/lightTheme.test.ts
+++ b/src/themes/rhdh/lightTheme.test.ts
@@ -83,7 +83,6 @@ describe("customLightTheme", () => {
         general: {
           disabledBackground: "#D2D2D2",
           disabled: "#6A6E73",
-          searchBarBorderColor: "#E4E4E4",
           formControlBackgroundColor: "#FFF",
           mainSectionBackgroundColor: "#FFF",
           headerBottomBorderColor: "#C7C7C7",

--- a/src/themes/rhdh/lightTheme.ts
+++ b/src/themes/rhdh/lightTheme.ts
@@ -32,7 +32,6 @@ export const customLightTheme = (): ThemeConfigPalette => {
       general: {
         disabledBackground: "#D2D2D2",
         disabled: "#6A6E73",
-        searchBarBorderColor: "#E4E4E4",
         formControlBackgroundColor: "#FFF",
         mainSectionBackgroundColor: "#FFF",
         headerBottomBorderColor: "#C7C7C7",

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,6 @@ export interface RHDHThemePalette {
   general: {
     disabledBackground: string;
     disabled: string;
-    searchBarBorderColor: string;
     formControlBackgroundColor: string;
     mainSectionBackgroundColor: string;
     headerBottomBorderColor: string;


### PR DESCRIPTION
The style is now already added in the home page `SearchBar` component: https://github.com/janus-idp/backstage-showcase/blob/main/plugins/dynamic-home-page/src/components/SearchBar.tsx#L9-L16

In that component, we might use a better-existing theme prop, then hard coded values. But I don't think we need a "search border" color anymore. 

/cc @ciiay 