### PR TITLE
RHIDP-3430: Use the primary color as default color for Checkboxes and Tabs in MUI v4 (similar to MUI v5)

### DIFF
--- a/src/stories/mui-v4/Checkbox.stories.tsx
+++ b/src/stories/mui-v4/Checkbox.stories.tsx
@@ -6,6 +6,7 @@ import FormControlLabel from "@material-ui/core/FormControlLabel";
 import FormGroup from "@material-ui/core/FormGroup";
 import FormHelperText from "@material-ui/core/FormHelperText";
 import FormLabel from "@material-ui/core/FormLabel";
+import Grid from "@material-ui/core/Grid";
 import type { Meta, StoryObj } from "@storybook/react";
 
 export default {
@@ -16,22 +17,38 @@ export default {
 } satisfies Meta;
 
 export const WithLabels: StoryObj = {
-  render: (args) => (
-    <FormGroup>
-      <FormControlLabel
-        control={<Checkbox defaultChecked />}
-        label="Label"
-        {...args}
-      />
-      <FormControlLabel control={<Checkbox />} label="Required" {...args} />
-      <FormControlLabel
-        disabled
-        control={<Checkbox />}
-        label="Disabled"
-        {...args}
-      />
-    </FormGroup>
-  ),
+  render: (args) => {
+    const colors = [undefined, "default", "primary", "secondary"] as const;
+    return (
+      <Grid container spacing={2}>
+        {colors.map((color) => (
+          <Grid key={color} item>
+            <h1>
+              Color: {color === undefined ? "undefined" : JSON.stringify(color)}
+            </h1>
+            <FormGroup>
+              <FormControlLabel
+                control={<Checkbox color={color} defaultChecked />}
+                label="Label"
+                {...args}
+              />
+              <FormControlLabel
+                control={<Checkbox color={color} />}
+                label="Required"
+                {...args}
+              />
+              <FormControlLabel
+                disabled
+                control={<Checkbox color={color} />}
+                label="Disabled"
+                {...args}
+              />
+            </FormGroup>
+          </Grid>
+        ))}
+      </Grid>
+    );
+  },
 };
 
 export const FormGroupExample: StoryObj = {

--- a/src/stories/mui-v5/Checkbox.stories.tsx
+++ b/src/stories/mui-v5/Checkbox.stories.tsx
@@ -6,6 +6,7 @@ import FormControlLabel from "@mui/material/FormControlLabel";
 import FormGroup from "@mui/material/FormGroup";
 import FormHelperText from "@mui/material/FormHelperText";
 import FormLabel from "@mui/material/FormLabel";
+import Stack from "@mui/material/Stack";
 import type { Meta, StoryObj } from "@storybook/react";
 
 export default {
@@ -16,27 +17,49 @@ export default {
 } satisfies Meta;
 
 export const WithLabels: StoryObj = {
-  render: (args) => (
-    <FormGroup>
-      <FormControlLabel
-        control={<Checkbox defaultChecked />}
-        label="Label"
-        {...args}
-      />
-      <FormControlLabel
-        required
-        control={<Checkbox />}
-        label="Required"
-        {...args}
-      />
-      <FormControlLabel
-        disabled
-        control={<Checkbox />}
-        label="Disabled"
-        {...args}
-      />
-    </FormGroup>
-  ),
+  render: (args) => {
+    const colors = [
+      undefined,
+      "primary",
+      "secondary",
+      "error",
+      "info",
+      "success",
+      "warning",
+      "default",
+    ] as const;
+
+    return (
+      <Stack spacing={2} direction="row">
+        {colors.map((color) => (
+          <Stack key={color} spacing={2} direction="column">
+            <h1>
+              Color: {color === undefined ? "undefined" : JSON.stringify(color)}
+            </h1>
+            <FormGroup>
+              <FormControlLabel
+                control={<Checkbox color={color} defaultChecked />}
+                label="Label"
+                {...args}
+              />
+              <FormControlLabel
+                required
+                control={<Checkbox color={color} />}
+                label="Required"
+                {...args}
+              />
+              <FormControlLabel
+                disabled
+                control={<Checkbox color={color} />}
+                label="Disabled"
+                {...args}
+              />
+            </FormGroup>
+          </Stack>
+        ))}
+      </Stack>
+    );
+  },
 };
 
 export const FormGroupExample: StoryObj = {

--- a/src/themes/rhdh/components.ts
+++ b/src/themes/rhdh/components.ts
@@ -215,6 +215,14 @@ export const components = (themeConfig: ThemeConfig): Components => {
     };
   }
 
+  if (options.inputs !== "mui") {
+    components.MuiCheckbox = {
+      defaultProps: {
+        color: "primary",
+      },
+    };
+  }
+
   // MUI accordion
   if (options.accordions !== "mui") {
     components.MuiAccordion = {

--- a/src/themes/rhdh/components.ts
+++ b/src/themes/rhdh/components.ts
@@ -398,6 +398,9 @@ export const components = (themeConfig: ThemeConfig): Components => {
   // MUI tabs
   if (options.tabs !== "mui") {
     components.MuiTabs = {
+      defaultProps: {
+        indicatorColor: "primary",
+      },
       styleOverrides: {
         root: {
           boxShadow: `0 -1px ${general.tabsBottomBorderColor} inset`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,8 @@ export interface ThemeOptions {
 
   inputs?: "patternfly" | "mui";
 
+  checkbox?: "patternfly" | "mui";
+
   accordions?: "patternfly" | "mui";
 
   sidebars?: "patternfly" | "mui";


### PR DESCRIPTION
This is another approach to fix [RHIDP-3430 Change checkbox and tab color to match PatternFly (RHDH Theme)](https://issues.redhat.com/browse/RHIDP-3430)

It must not make #45 obsolete; we may need both. To be discussed...

The Backstage catalog filter uses the MUI v4 Checkbox without a `color` prop defined.

https://github.com/backstage/backstage/blob/27b099cbe24d3fcdaa9b032c335fa83f4b9cd6f2/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx#L89-L103

I've added some tests in our storybook to see how MUI v4 and v5 Checkboxes behaves:

### In MUI v4 no color means that the secondary color was automatically picked up:

Backstage default vs RHDH default vs RHDH with some custom colors:

| Before | With this PR |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/fec4b256-55fe-4155-a00e-56abf9167630) | no change in the backstage theme |
| ![image](https://github.com/user-attachments/assets/701dff06-89e8-4cfd-bbae-874e14a6f704)<br><br>No color uses the **_secondary_** color by default | ![image](https://github.com/user-attachments/assets/d619a13e-4f66-4e0d-93d1-df3f855162cb)<br><br>No color uses the **_primary_** color by default |
| ![image](https://github.com/user-attachments/assets/1b379f37-fca8-4df7-ad4b-f64c6603721a)<br><br>No color uses the **_secondary_** color by default | ![image](https://github.com/user-attachments/assets/7aa6c26e-88e7-421f-9fa8-9d23047df451)<br><br>No color uses the **_primary_** color by default |
| ![image](https://github.com/user-attachments/assets/00b8c958-22cf-438b-af90-7b62e1a3036c) | no change in the backstage theme |
| ![image](https://github.com/user-attachments/assets/caa8a0ab-6545-4648-b498-e37f4bc338cf)<br><br>No color uses the **_secondary_** color by default | ![image](https://github.com/user-attachments/assets/108bbc3c-6662-4456-920d-e1582ef1dce7)<br><br>No color uses the **_primary_** color by default |
| ![image](https://github.com/user-attachments/assets/2aaa904f-2acf-415f-bde8-5ceaea281bbf)<br><br>No color uses the **_secondary_** color by default | ![image](https://github.com/user-attachments/assets/11e257b7-6610-4f2e-a601-eb65e331e169)<br><br>No color uses the **_primary_** color by default |

### While in MUI v5 the primary color was automatically picked up (as expected or at least similar to buttons)

Backstage default vs RHDH default vs RHDH with some custom colors:

| Before | With this PR |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/4f1770de-263c-4c2a-a758-1867fba0b933) | no change in the backstage theme |
| ![image](https://github.com/user-attachments/assets/5274fa6d-944e-49ce-b366-3a08b6f2c043)<br><br>No color uses the **primary** color by default |![image](https://github.com/user-attachments/assets/a06d5ed7-b56c-4691-8614-029737ed352e)<br><br>No color uses the primary color by default **as before** |
| ![image](https://github.com/user-attachments/assets/185bb342-91e7-4914-a632-2290ca652fd4)<br><br>No color uses the **primary** color by default | ![image](https://github.com/user-attachments/assets/13331dbf-0606-4410-b9b3-7e7174dd55e9)<br><br>No color uses the primary color by default **as before** |
| ![image](https://github.com/user-attachments/assets/ddd9116d-5d3f-44a1-8746-470c5170b8ad) | no change in the backstage theme |
| ![image](https://github.com/user-attachments/assets/42aec8a3-88d6-44cf-909a-ac61f1ed1369)<br><br>No color uses the **primary** color by default | ![image](https://github.com/user-attachments/assets/4d84e55d-9d80-45da-8a78-445529af3e1d)<br><br>No color uses the primary color by default **as before** |
| ![image](https://github.com/user-attachments/assets/2d814ed7-557a-4354-a2f8-943340c91d29)<br><br>No color uses the **primary** color by default | ![image](https://github.com/user-attachments/assets/9909b55d-974e-4720-a7dc-a6eea963c965)<br><br>No color uses the primary color by default **as before** |

/cc @ciiay @ShiranHi @debsmita1 
