### PR TITLE
Add global header style

### DIFF
--- a/src/themes/rhdh/components.ts
+++ b/src/themes/rhdh/components.ts
@@ -98,14 +98,12 @@ export const components = (themeConfig: ThemeConfig): Components => {
   }
 
   // MUI AppBar
-  if (options.headers !== "mui") {
+  if (options.appBar !== "mui") {
     components.MuiAppBar = {
       styleOverrides: {
         root: {
-          backgroundColor:
-            general.globalHeaderBackgroundColor ??
-            general.sidebarBackgroundColor,
-          backgroundImage: "none",
+          backgroundColor: general.appBarBackgroundColor,
+          backgroundImage: general.appBarBackgroundImage,
         },
       },
     };

--- a/src/themes/rhdh/components.ts
+++ b/src/themes/rhdh/components.ts
@@ -102,11 +102,13 @@ export const components = (themeConfig: ThemeConfig): Components => {
     components.MuiAppBar = {
       styleOverrides: {
         root: {
-          backgroundColor: general.globalHeaderBackgroundColor ?? general.sidebarBackgroundColor,
+          backgroundColor:
+            general.globalHeaderBackgroundColor ??
+            general.sidebarBackgroundColor,
           backgroundImage: "none",
         },
       },
-    }
+    };
   }
 
   // MUI buttons

--- a/src/themes/rhdh/components.ts
+++ b/src/themes/rhdh/components.ts
@@ -102,7 +102,7 @@ export const components = (themeConfig: ThemeConfig): Components => {
     components.MuiAppBar = {
       styleOverrides: {
         root: {
-          backgroundColor: general.sidebarBackgroundColor,
+          backgroundColor: general.globalHeaderBackgroundColor ?? general.sidebarBackgroundColor,
           backgroundImage: "none",
         },
       },
@@ -156,6 +156,11 @@ export const components = (themeConfig: ThemeConfig): Components => {
         outlined: {
           "&:hover": {
             backgroundColor: "transparent",
+          },
+          "&:disabled": {
+            color: general.disabled,
+            backgroudColor: general.disabledBackground,
+            border: `1px solid ${general.disabledBackground}`,
           },
         },
         outlinedPrimary: {
@@ -478,7 +483,7 @@ export const components = (themeConfig: ThemeConfig): Components => {
       styleOverrides: {
         drawer: {
           backgroundColor:
-            general.sidebarBackgroundColor ?? general.sidebarBackgroundColor,
+            general.sidebarBackgroundColor ?? general.sideBarBackgroundColor,
           '& a[class*="BackstageSidebarItem-selected-"]': {
             backgroundColor: general.sidebarItemSelectedBackgroundColor,
           },

--- a/src/themes/rhdh/components.ts
+++ b/src/themes/rhdh/components.ts
@@ -97,6 +97,18 @@ export const components = (themeConfig: ThemeConfig): Components => {
     };
   }
 
+  // MUI AppBar
+  if (options.headers !== "mui") {
+    components.MuiAppBar = {
+      styleOverrides: {
+        root: {
+          backgroundColor: general.sidebarBackgroundColor,
+          backgroundImage: "none",
+        },
+      },
+    }
+  }
+
   // MUI buttons
   // Don't disableRipple for MuiButtonBase as it will affect all the buttons
   // and we need to ensure that the buttons have a right touch and focus styling.
@@ -466,7 +478,7 @@ export const components = (themeConfig: ThemeConfig): Components => {
       styleOverrides: {
         drawer: {
           backgroundColor:
-            general.sidebarBackgroundColor ?? general.sideBarBackgroundColor,
+            general.sidebarBackgroundColor ?? general.sidebarBackgroundColor,
           '& a[class*="BackstageSidebarItem-selected-"]': {
             backgroundColor: general.sidebarItemSelectedBackgroundColor,
           },

--- a/src/themes/rhdh/darkTheme.test.ts
+++ b/src/themes/rhdh/darkTheme.test.ts
@@ -94,6 +94,8 @@ describe("customDarkTheme", () => {
           tableBackgroundColor: "#1b1d21",
           tabsBottomBorderColor: "#444548",
           contrastText: "#FFF",
+          appBarBackgroundColor: "#1b1d21",
+          appBarBackgroundImage: "none",
         },
         primary: {
           main: "#1FA7F8",

--- a/src/themes/rhdh/darkTheme.ts
+++ b/src/themes/rhdh/darkTheme.ts
@@ -43,7 +43,8 @@ export const customDarkTheme = (): ThemeConfigPalette => {
         tableBackgroundColor: "#1b1d21",
         tabsBottomBorderColor: "#444548",
         contrastText: "#FFF",
-        globalHeaderBackgroundColor: "#1b1d21",
+        appBarBackgroundColor: "#1b1d21",
+        appBarBackgroundImage: "none",
       },
       primary: {
         main: "#1FA7F8",

--- a/src/themes/rhdh/darkTheme.ts
+++ b/src/themes/rhdh/darkTheme.ts
@@ -43,6 +43,7 @@ export const customDarkTheme = (): ThemeConfigPalette => {
         tableBackgroundColor: "#1b1d21",
         tabsBottomBorderColor: "#444548",
         contrastText: "#FFF",
+        globalHeaderBackgroundColor: "#1b1d21",
       },
       primary: {
         main: "#1FA7F8",

--- a/src/themes/rhdh/lightTheme.test.ts
+++ b/src/themes/rhdh/lightTheme.test.ts
@@ -98,6 +98,8 @@ describe("customLightTheme", () => {
           tableBackgroundColor: "#FFF",
           tabsBottomBorderColor: "#D2D2D2",
           contrastText: "#FFF",
+          appBarBackgroundColor: "#212427",
+          appBarBackgroundImage: "none",
         },
         primary: {
           main: "#0066CC",

--- a/src/themes/rhdh/lightTheme.ts
+++ b/src/themes/rhdh/lightTheme.ts
@@ -47,7 +47,8 @@ export const customLightTheme = (): ThemeConfigPalette => {
         tableBackgroundColor: "#FFF",
         tabsBottomBorderColor: "#D2D2D2",
         contrastText: "#FFF",
-        globalHeaderBackgroundColor: "#212427",
+        appBarBackgroundColor: "#212427",
+        appBarBackgroundImage: "none",
       },
       primary: {
         main: "#0066CC",

--- a/src/themes/rhdh/lightTheme.ts
+++ b/src/themes/rhdh/lightTheme.ts
@@ -47,6 +47,7 @@ export const customLightTheme = (): ThemeConfigPalette => {
         tableBackgroundColor: "#FFF",
         tabsBottomBorderColor: "#D2D2D2",
         contrastText: "#FFF",
+        globalHeaderBackgroundColor: "#212427",
       },
       primary: {
         main: "#0066CC",

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export interface RHDHThemePalette {
     tableBackgroundColor: string;
     tabsBottomBorderColor: string;
     contrastText: string;
+    globalHeaderBackgroundColor: string;
   };
 
   primary: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,8 @@ export interface RHDHThemePalette {
     tableBackgroundColor: string;
     tabsBottomBorderColor: string;
     contrastText: string;
-    globalHeaderBackgroundColor: string;
+    appBarBackgroundColor: string;
+    appBarBackgroundImage: string;
   };
 
   primary: {
@@ -86,6 +87,8 @@ export interface ThemeOptions {
   tables?: "patternfly" | "mui";
 
   tabs?: "patternfly" | "mui";
+
+  appBar?: "patternfly" | "mui";
 }
 
 export interface ThemeConfig {


### PR DESCRIPTION
Added styles for global header.

Now global header background color is customizable using the following configuration in `app-config.yaml`

```
app:
    theme:
      light: # or dark
        palette:
          rhdh:
            general:
              appBarBackgroundColor: '#d25f78'
```