### PR TITLE
fix: mui outlined button missing border issue

### DIFF
--- a/.changeset/old-kings-exercise.md
+++ b/.changeset/old-kings-exercise.md
@@ -1,0 +1,5 @@
+---
+"@redhat-developer/red-hat-developer-hub-theme": patch
+---
+
+Fixed Mui outlined button style issue

--- a/src/themes/rhdh/components.ts
+++ b/src/themes/rhdh/components.ts
@@ -120,10 +120,10 @@ export const components = (themeConfig: ThemeConfig): Components => {
       styleOverrides: {
         root: {
           textTransform: "none",
-          border: "0",
           borderRadius: "3px",
         },
         contained: {
+          border: "0",
           boxShadow: "none",
           "&:hover": {
             border: "0",


### PR DESCRIPTION
For [RHIDP-6603](https://issues.redhat.com/browse/RHIDP-6603)
![image](https://github.com/user-attachments/assets/b95bd3ea-5fb6-488f-be0a-b735f8a4486e)
